### PR TITLE
atom and gdata packages were not importable when installed via pip or pipenv.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='gdata',
       description='Python client library for Google data APIs',
       long_description="""\
 The Google data Python client library makes it easy to interact with
-Google services through the Google Data APIs. This library provides data 
+Google services through the Google Data APIs. This library provides data
 models and service modules for the the following Google data services:
 - Google Calendar data API
 - Google Contacts data API
@@ -40,9 +40,9 @@ models and service modules for the the following Google data services:
 - Google Content API For Shopping
 - Google App Marketplace API
 - Google Content API for Shopping
-- core Google data API functionality 
-The core Google data code provides sufficient functionality to use this 
-library with any Google data API (even if a module hasn't been written for 
+- core Google data API functionality
+The core Google data code provides sufficient functionality to use this
+library with any Google data API (even if a module hasn't been written for
 it yet). For example, this client can be used with the Notebook API. This
 library may also be used with any Atom Publishing Protocol service (AtomPub).
 """,
@@ -85,7 +85,7 @@ library may also be used with any Atom Publishing Protocol service (AtomPub).
           'gdata.webmastertools',
           'gdata.youtube',
       ],
-      package_dir={'gdata': 'src/gdata', 'atom': 'src/atom'},
+      package_dir={'': 'src'},
       classifiers=[
           'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Modified setup.py to modify package_dir as per this comment https://github.com/pypa/pip/issues/126#issuecomment-874855

Following this change, I was able to import atom and gdata on a fresh python 3.6.7 virtualenv.