### PR TITLE
bug fixes for blogger blog id parsing

### DIFF
--- a/src/gdata/blogger/data.py
+++ b/src/gdata/blogger/data.py
@@ -21,7 +21,7 @@ THR_TEMPLATE = '{http://purl.org/syndication/thread/1.0}%s'
 
 BLOG_NAME_PATTERN = re.compile('(http://)(\w*)')
 BLOG_ID_PATTERN = re.compile('(tag:blogger.com,1999:blog-)(\w*)')
-BLOG_ID2_PATTERN = re.compile('tag:blogger.com,1999:user-(\d+)\.blog-(\d+)')
+BLOG_ID2_PATTERN = re.compile('tag:blogger.com,1999:user-g?(\d+)\.blog-(\d+)')
 POST_ID_PATTERN = re.compile(
     '(tag:blogger.com,1999:blog-)(\w*)(.post-)(\w*)')
 PAGE_ID_PATTERN = re.compile(
@@ -43,13 +43,12 @@ class BloggerEntry(gdata.data.GDEntry):
         Returns:
           The blog's unique id as a string.
         """
-        if self.id.text:
-            match = BLOG_ID_PATTERN.match(self.id.text)
+        if not self.id.text:
+            return None
+        for pattern in BLOG_ID_PATTERN, BLOG_ID2_PATTERN:
+            match = pattern.match(self.id.text)
             if match:
                 return match.group(2)
-            else:
-                return BLOG_ID2_PATTERN.match(self.id.text).group(2)
-        return None
 
     GetBlogId = get_blog_id
 


### PR DESCRIPTION
specifically:
* handle new style blogger blog ids prefixed with g. details in snarfed/bridgy#168
* don't crash if blog id can't be parsed. details in snarfed/bridgy#147

i filed this against the original repo a while back, in google/gdata-python-client#27. it was never merged (heh), but i still use gdata from my fork, and i'm now porting my app to Python 3, so i'd love to use your port. thank you so much for working on it!