### PR TITLE
bytes/string conversion fix for p_sock.sendall() and p_sock.recv()

### DIFF
--- a/src/atom/http_core.py
+++ b/src/atom/http_core.py
@@ -552,11 +552,11 @@ class ProxiedHttpClient(HttpClient):
             # Connect to the proxy server, very simple recv and error checking
             p_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             p_sock.connect((proxy_uri.host, int(proxy_uri.port)))
-            p_sock.sendall(proxy_pieces)
+            p_sock.sendall(proxy_pieces.encode('utf-8'))
             response = ''
             # Wait for the full response.
             while response.find("\r\n\r\n") == -1:
-                response += p_sock.recv(8192)
+                response += p_sock.recv(8192).decode('utf-8')
             p_status = response.split()[1]
             if p_status != str(200):
                 raise ProxyError('Error status=%s' % str(p_status))


### PR DESCRIPTION
This patch fixes two bytes/string conversion steps missed during the Python2 =>3 migration:

1)
proxy_pieces - is sting
p_sock.sendall - expects bytes

File "src/atom/http_core.py", line 555, in _get_connection
    p_sock.sendall(proxy_pieces)
TypeError: a bytes-like object is required, not 'str'

2)
response - is concatenated as sting
p_sock.recv - returns bytes 

File "src/atom/http_core.py", line 559, in _get_connection
    response += p_sock.recv(8192)
TypeError: can only concatenate str (not "bytes") to str

